### PR TITLE
Make launch path relative to workspace

### DIFF
--- a/tutorial/Build Tutorial WAR File.launch
+++ b/tutorial/Build Tutorial WAR File.launch
@@ -10,5 +10,5 @@
 <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
 <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
 <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="C:/Users/Stefan/git/requestfactory_local/tutorial"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/tutorial}"/>
 </launchConfiguration>


### PR DESCRIPTION
There were some local settings in the launcher. I replaced them with a workspace relative path.
